### PR TITLE
Support importing as module in swift

### DIFF
--- a/react-native-bare-kit.podspec
+++ b/react-native-bare-kit.podspec
@@ -28,6 +28,10 @@ Pod::Spec.new do |s|
 
   s.vendored_frameworks = "ios/*.xcframework", "ios/addons/*.xcframework"
 
+  s.header_dir = "BareKit"
+
+  s.module_name = "react_native_bare_kit"
+
   s.prepare_command = "node ios/prepare"
 
   install_modules_dependencies(s)


### PR DESCRIPTION
Without `header_dir` cocoapods generates invalid umbrella header which breaks build when importing as module from swift.
`header_dir` however also modifies module name, so `module_name` is also needed.